### PR TITLE
Make CI/CD workflows fully passwordless (drop AZURE_OPENAI_API_KEY and AZURE_CREDENTIALS)

### DIFF
--- a/.github/workflows/ai-opsec-agent.yml
+++ b/.github/workflows/ai-opsec-agent.yml
@@ -16,21 +16,44 @@ on:
 
 
 permissions:
+  id-token: write       # required for OIDC federated login to Azure
   contents: read
-  pull-requests: write # so we can comment on PRs
+  pull-requests: write  # so we can comment on PRs
 
 jobs:
   audit:
     runs-on: ubuntu-latest
     name: "Audit Codebase"
     steps:
-      - name: Checkout code 
+      - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Log in to Azure (OIDC)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Get Azure OpenAI access token
+        id: aoai-token
+        shell: bash
+        run: |
+          token=$(az account get-access-token \
+            --resource https://cognitiveservices.azure.com \
+            --query accessToken -o tsv)
+          echo "::add-mask::$token"
+          echo "token=$token" >> "$GITHUB_OUTPUT"
+
       - name: Audit Codebase
         uses: Azure-Samples/azure-ai-travel-agents/.github/actions/ai-opsec-agent@main
         with:
-            AZURE_OPENAI_ENDPOINT: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
-            AZURE_OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}
+            AZURE_OPENAI_ENDPOINT: ${{ vars.AZURE_OPENAI_ENDPOINT }}
+            # Passwordless: pass an Entra ID access token in place of a static API key.
+            # Azure OpenAI accepts an Entra ID bearer token in the same Authorization header.
+            # The federated service principal (vars.AZURE_CLIENT_ID) must have the
+            # "Cognitive Services OpenAI User" role on the Azure OpenAI resource.
+            AZURE_OPENAI_API_KEY: ${{ steps.aoai-token.outputs.token }}
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             output: security-audit.md
         

--- a/.github/workflows/azure-dev.yml
+++ b/.github/workflows/azure-dev.yml
@@ -38,27 +38,12 @@ jobs:
               uses: Azure/setup-azd@v2
 
             - name: Log in with Azure (Federated Credentials)
-              if: ${{ env.AZURE_CLIENT_ID != '' }}
               run: |
                 azd auth login `
                 --client-id "$Env:AZURE_CLIENT_ID" `
                 --federated-credential-provider "github" `
                 --tenant-id "$Env:AZURE_TENANT_ID"
               shell: pwsh
-
-            - name: Log in with Azure (Client Credentials)
-              if: ${{ env.AZURE_CREDENTIALS != '' }}
-              run: |
-                $info = $Env:AZURE_CREDENTIALS | ConvertFrom-Json -AsHashtable;
-                Write-Host "::add-mask::$($info.clientSecret)"
-
-                azd auth login `
-                --client-id "$($info.clientId)" `
-                --client-secret "$($info.clientSecret)" `
-                --tenant-id "$($info.tenantId)"
-              shell: pwsh
-              env:
-                AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
 
             - name: Provision Infrastructure
               run: azd provision --no-prompt

--- a/README.md
+++ b/README.md
@@ -196,6 +196,36 @@ To run the sample, run the following commands, which will start the Next.js app.
 
 Open the URL `http://localhost:3000` in your browser to interact with the Assistant.
 
+## CI/CD configuration (passwordless)
+
+The workflows in `.github/workflows/` authenticate to Azure with **GitHub OIDC + Microsoft Entra ID federated credentials**. They do **not** use a static client secret or an Azure OpenAI API key.
+
+### Required repository variables
+
+Configure these under **Settings → Secrets and variables → Actions → Variables**:
+
+| Variable | Used by | Notes |
+| --- | --- | --- |
+| `AZURE_CLIENT_ID` | both workflows | App registration (service principal) client ID |
+| `AZURE_TENANT_ID` | both workflows | Entra ID tenant ID |
+| `AZURE_SUBSCRIPTION_ID` | both workflows | Target Azure subscription |
+| `AZURE_ENV_NAME` | `azure-dev.yml` | `azd` environment name |
+| `AZURE_LOCATION` | `azure-dev.yml` | Azure region (e.g., `swedencentral`) |
+| `AZURE_OPENAI_ENDPOINT` | `ai-opsec-agent.yml` | Endpoint URL of the Azure OpenAI resource (not a secret) |
+
+### Required Azure-side configuration
+
+1. **Federated credential** on the app registration (`AZURE_CLIENT_ID`) trusting this repo's `main` branch and pull requests. `azd pipeline config` will create this for you.
+2. **Entra ID authentication enabled** on the Azure OpenAI resource (`AZURE_OPENAI_ENDPOINT`).
+3. **Role assignment**: grant the service principal the **Cognitive Services OpenAI User** role on the Azure OpenAI resource so the OpSec workflow can request an access token.
+
+### Secrets that must **not** be set
+
+These are deliberately unused. If they exist in repo settings, delete them:
+
+- `AZURE_CREDENTIALS` (client-secret JSON — replaced by federated credentials)
+- `AZURE_OPENAI_API_KEY` (replaced by an Entra ID access token obtained at runtime)
+
 ## Guidance
 
 ### Region Availability

--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ These are deliberately unused. If they exist in repo settings, delete them:
 
 - `AZURE_CREDENTIALS` (client-secret JSON — replaced by federated credentials)
 - `AZURE_OPENAI_API_KEY` (replaced by an Entra ID access token obtained at runtime)
+- `AZURE_OPENAI_ENDPOINT` (endpoint URL — should be an Actions variable, not a secret)
 
 ## Guidance
 


### PR DESCRIPTION
## Summary

Drops the last two long-lived secrets this repo depended on and standardizes both workflows on GitHub OIDC + Microsoft Entra ID federated credentials. After this PR, the repo has no static client secret and no Azure OpenAI API key.

## Changes

### `.github/workflows/ai-opsec-agent.yml`
- Add `id-token: write` permission.
- Add `azure/login@v2` step using repo variables (`AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID`).
- Request an Azure OpenAI access token via `az account get-access-token --resource https://cognitiveservices.azure.com` and mask it.
- Pass that token to the upstream composite action''s existing `AZURE_OPENAI_API_KEY` input. Azure OpenAI accepts an Entra ID bearer token in the same `Authorization: Bearer` header, so no upstream action change is required.
- Move `AZURE_OPENAI_ENDPOINT` from `secrets.*` to `vars.*` — endpoint URLs are not secrets.

### `.github/workflows/azure-dev.yml`
- Remove the `AZURE_CREDENTIALS` client-secret fallback login step entirely.
- Drop the now-unnecessary `if:` guard on the federated-credentials login step; OIDC is the only path.

### `README.md`
- New **CI/CD configuration (passwordless)** section documenting required repo variables, the federated credential, the `Cognitive Services OpenAI User` role assignment, and the secrets that must not be set.

## Manual repo-settings checklist (must be done alongside merge)

> ⚠️ Without these Azure-side steps, the OpSec workflow will start failing on the next run after merge. Please coordinate the merge with the role assignment.

- [ ] **Enable Microsoft Entra ID authentication** on the Azure OpenAI resource referenced by `AZURE_OPENAI_ENDPOINT`.
- [ ] **Grant** the federated service principal (`vars.AZURE_CLIENT_ID`) the **Cognitive Services OpenAI User** role on that Azure OpenAI resource.
- [ ] **Verify** the federated identity credential on the app registration trusts this repo''s `main` branch and pull requests.
- [ ] **Add repo variable** `AZURE_OPENAI_ENDPOINT` (Settings → Secrets and variables → Actions → Variables).
- [ ] **Delete repo secrets**: `AZURE_OPENAI_API_KEY`, `AZURE_CREDENTIALS`, and (if present as a secret) `AZURE_OPENAI_ENDPOINT`.

## Out of scope / follow-up

- A separate upstream PR to `Azure-Samples/azure-ai-travel-agents` to add a first-class `AZURE_OPENAI_ACCESS_TOKEN` input to the `ai-opsec-agent` composite action would let us rename the input here for clarity. Not required for this change to work.

## Testing

- YAML parsed cleanly (`python -c "import yaml; yaml.safe_load(...)"` on both workflows).
- No behavioral change to the OpSec audit itself; only how the model call is authenticated.
- `azure-dev.yml` is now a strict subset of its previous behavior: anyone who was already using OIDC is unaffected; anyone who was using `AZURE_CREDENTIALS` needs to switch to federated credentials (matches the documented `azd pipeline config` flow).
